### PR TITLE
Avoid duplicate SimpleRand instance and two parallel random sequences based on same seed

### DIFF
--- a/chat.pony
+++ b/chat.pony
@@ -112,9 +112,10 @@ actor Client
     _id = id
     _friends = FriendSet
     _chats = ChatSet
-    _dice = DiceRoll(seed)
     _directory = directory
     _rand = SimpleRand(seed)
+    _dice = DiceRoll(_rand)
+
 
   be befriend(client: Client) =>
     _friends.set(client)

--- a/util/random.pony
+++ b/util/random.pony
@@ -12,14 +12,14 @@ class SimpleRand is Random
   fun ref nextLong(): U64 =>
     _value = ((_value * 1309) + 13849) and 65535
     _value
-  
+
   fun ref nextInt(max: U32 = 0): U32 =>
     if max == 0 then
       nextLong().u32()
     else
       nextLong().u32() % max
     end
-  
+
   fun ref nextDouble(): F64 =>
     1.0 / (nextLong() + 1).f64()
 
@@ -30,7 +30,7 @@ class CongruentialRand is Random
 
   new create(x: U64, y: U64 = 0) =>
     _x = (x xor U64(0x5DEECE66D)) and ((U64(1) << 48) -1)
-    
+
   fun ref next_mask(bits: U64): U64 =>
     next() >> U64(48 - bits)
 
@@ -56,7 +56,7 @@ class CongruentialRand is Random
   fun ref nextGaussian(): F64 =>
     """
     Returns the next gaussian normally distributed
-    random number with mean 0.0 and a standard 
+    random number with mean 0.0 and a standard
     deviation of 1.0. Implemented using the polar
     method as described by G.E.P Box, M.E. Muller
     and G. Marsaglia.

--- a/util/random.pony
+++ b/util/random.pony
@@ -86,8 +86,8 @@ class CongruentialRand is Random
 class DiceRoll
   let _random: SimpleRand
 
-  new create(seed: U64) =>
-    _random = SimpleRand(seed)
+  new create(rand: SimpleRand) =>
+    _random = rand
 
   fun ref apply(probability: U64): Bool =>
     _random.nextInt(100) < probability.u32()


### PR DESCRIPTION
I am starting to adapt my version of the benchmark to follow the latest one as close as possible.

I noted a little things, which I wonder whether it's worth changing.

The client has `_dice` and `_rand` based on the same seed, and in both cases a `SimpleRand` is created. Is one sufficient?

It would avoid having the same PRNG sequence twice.