### PR TITLE
Move Directories to Poker, and avoid use of Rand

### DIFF
--- a/chat.pony
+++ b/chat.pony
@@ -305,9 +305,8 @@ actor Poker
   var _bench: (AsyncBenchmarkCompletion | None)
   var _last: Bool
   var _turn_series: Array[F64]
-  var _env: Env
 
-  new create(clients: U64, turns: U64, directories: Array[Directory] val, factory: BehaviorFactory, env: Env) =>
+  new create(clients: U64, turns: U64, directories: Array[Directory] val, factory: BehaviorFactory) =>
     _actions = ActionMap
     _clients = clients
     _logouts = 0
@@ -322,7 +321,6 @@ actor Poker
     _bench = None
     _last = false
     _turn_series = Array[F64]
-    _env = env
 
   be apply(bench: AsyncBenchmarkCompletion, last: Bool) =>
     _confirmations = _turns.usize()
@@ -497,7 +495,7 @@ class iso ChatApp is AsyncActorBenchmark
       dirs
     end
 
-    _poker = Poker(_clients, _turns, _directories, _factory, env)
+    _poker = Poker(_clients, _turns, _directories, _factory)
 
   fun box apply(c: AsyncBenchmarkCompletion, last: Bool) => _poker(c, last)
 

--- a/chat.pony
+++ b/chat.pony
@@ -177,12 +177,11 @@ actor Client
         f.push(friend)
       end
 
-      let s = Rand(_rand.next())
-      s.shuffle[Client](f)
+      _rand.shuffle[Client](f)
 
       f.unshift(this)
 
-      var invitations: USize = s.next().usize() % _friends.size()
+      var invitations: USize = _rand.next().usize() % _friends.size()
 
       if invitations == 0 then
         accumulator.stop(Invite)

--- a/util/random.pony
+++ b/util/random.pony
@@ -1,10 +1,8 @@
-use "random"
-
-class SimpleRand is Random
+class SimpleRand
   var _value: U64
 
-  new create(x: U64, y: U64 = 0) =>
-    _value = x
+  new create(seed: U64) =>
+    _value = seed
 
   fun ref next(): U64 =>
     nextLong()
@@ -23,7 +21,19 @@ class SimpleRand is Random
   fun ref nextDouble(): F64 =>
     1.0 / (nextLong() + 1).f64()
 
-class CongruentialRand is Random
+  fun ref shuffle[A](array: Array[A]) =>
+    """
+    Shuffle the elements of the array into a random order, mutating the array.
+    """
+    var i: USize = array.size()
+    try
+      while i > 1 do
+        let ceil = i = i - 1
+        array.swap_elements(i, nextInt(ceil.u32()).usize())?
+      end
+    end
+
+class CongruentialRand
   var _x: U64
   var _next_gaussian: F64 = 0
   var _has_next_gaussian: Bool = false


### PR DESCRIPTION
I'd like to propose a few localized changes:

- remove env from Poker, since it is not used
- move the dictionary creation from ChatApp to Poker since only the poker really uses it, and it makes it easier in actor languages which do not allow sending around structured data as easily
- avoid the use of Pony's Rand class by having a copy of the shuffle method in the SimpleRand class

Happy to discuss/improve the changes.