### PR TITLE
Newspeak: Avoid use of far reference identity to reduce concurrency issues

### DIFF
--- a/newspeak/chat.ns
+++ b/newspeak/chat.ns
@@ -310,7 +310,7 @@ class Chat usingPlatform: platform = Value (
 
     public poke: factory accu: accumulator = (
       clients doWithTuple: [:tuple |
-        tuple at: 2 put: ((tuple at: 2) <-: act: factory accu: accumulator) ]
+        (tuple at: 2) <-: act: factory accu: accumulator ]
     )
 
     public disconnect: p = (

--- a/newspeak/chat.ns
+++ b/newspeak/chat.ns
@@ -16,42 +16,87 @@ class Chat usingPlatform: platform = Value (
 |
 )(
   private class IdPromiseVector new: size = Vector new: size (
-  | private nonEmptyElements ::= 0. |
   )(
     public append: id and: promise = (
-      self append: {id. promise}
+      append: {id. promise}
+    )
+
+    public promiseAt: idx = (
+      ^ (at: idx) at: 2
+    )
+
+    private moveUpRemainingAt: i = (
+      lastIdx:: lastIdx - 1.
+      i + 1 to: lastIdx do: [:j |
+        storage at: j - 1 put: (storage at: j) ]
     )
 
     public removeById: id <Integer> = (
       doIndexes: [:i |
-        | tuple = promiseVec at: i. |
-        tuple ~= nil ifTrue: [
-          (tuple at: 1) = id ifTrue: [
-            promiseVec at: i put: nil.
-            nonEmptyElements:: nonEmptyElements - 1.
-            ^ true ] ] ].
+        | tuple = at: i. |
+        (tuple at: 1) = id ifTrue: [
+          moveUpRemainingAt: i.
+          ^ true ] ].
 
       ^ false
+    )
 
-      (* TODO: need to support indexed access *)
+    public do: block = (
+      super do: [:tuple |
+        block value: (tuple at: 1) with: (tuple at: 2) ]
     )
 
     public doWithPromise: block = (
-      do: [:tuple |
-        tuple ~= nil ifTrue: [
-          block value: (tuple at: 2) ] ]
+      super do: [:tuple |
+        block value: (tuple at: 2) ]
     )
 
-    public size = (
-      ^ nonEmptyElements
+    public doWithTuple: block = (
+      super do: block
     )
 
-    public isEmpty = (
-      ^ nonEmptyElements = 0
+    public println = (
+      'Vector[' print.
+      firstIdx print. ', ' print.
+      lastIdx print. ': ' print.
+      self do: [ :it | '(' print. (it at: 1) print. ':' print. (it at: 2) print. ')' print ].
+      ']' println
     )
   ) : (
     public new = (
       ^ self new: 10
+    )
+
+    public testRemove = (
+      | vec |
+      vec:: IdPromiseVector new: 10.
+      vec println.
+
+      vec append: 1 and: #a.
+      vec append: 2 and: #b.
+      vec append: 3 and: #c.
+      vec append: 4 and: #d.
+      vec append: 5 and: #e.
+      vec append: 6 and: #f.
+      vec append: 7 and: #g.
+      vec append: 8 and: #h.
+      vec append: 9 and: #j.
+      vec append: 10 and: #k.
+
+      vec println.
+
+      vec removeById: 2.
+
+      vec println.
+
+      vec removeById: 3.
+      vec removeById: 8.
+
+      vec println.
+
+      vec removeById: 10.
+
+      vec println.
     )
   )
 
@@ -198,9 +243,10 @@ class Chat usingPlatform: platform = Value (
         ^ self ].
 
       b = #invite ifTrue: [
-        | createdP <Promise[Chat]> f i invitations |
+        | createdP <Promise[Chat]> f i invitations chatId |
         nextChatId:: nextChatId + 1.
-        createdP:: (actors createActorFromValue: Chat) <-: new: self clientId: id chatId: (id << 20) + nextChatId.
+        chatId:: (id << 20) + nextChatId.
+        createdP:: (actors createActorFromValue: Chat) <-: new: self clientId: id chatId: chatId.
         f:: friends asArray.
 
         rand shuffle: f.
@@ -214,8 +260,7 @@ class Chat usingPlatform: platform = Value (
 
         accumulator <-: bump: invitations act: #invite.
 
-        createdP whenResolved: [:created |
-          chats append: created ].
+        chats append: chatId and: createdP.
 
         1 to: invitations do: [:i |
           | k = f at: i. |
@@ -236,35 +281,27 @@ class Chat usingPlatform: platform = Value (
   |)(
     public login: id = (
       | newClient = (actors createActorFromValue: Client) <-: create: id dir: self seed: random next. |
-      clients append: {id. newClient}.
-      numClients:: numClients + 1.
+      clients append: id and: newClient
     )
 
     public befriend = (
-      clients do: [:friendTuple |
-        friendTuple ~= nil ifTrue: [
-          | friend fId madeFriends |
-          friend:: friendTuple at: 2.
-          fId:: friendTuple at: 1.
-          madeFriends:: false.
+      clients do: [:fId :friend |
+        | madeFriends |
+        madeFriends:: false.
 
-          [madeFriends] whileFalse: [
-            clients do: [:clientTuple |
-              clientTuple ~= nil ifTrue: [
-                | client cId |
-                client:: clientTuple at: 2.
-                cId:: clientTuple at: 1.
-                ((random nextInt: 100) < numBefriends and: [fId <> cId])
-                  ifTrue: [
-                    madeFriends:: true.
-                    client <-: befriend: friend.
-                    friend <-: befriend: client ] ] ] ] ] ]
+        [madeFriends] whileFalse: [
+          clients do: [:cId :client |
+            ((random nextInt: 100) < numBefriends and: [fId <> cId])
+              ifTrue: [
+                madeFriends:: true.
+                client <-: befriend: friend clientId: fId.
+                friend <-: befriend: client clientId: cId ] ] ] ]
     )
 
     public left: clientId <Integer> = (
-      remove: clientId.
+      clients removeById: clientId.
 
-      numClients = 0 ifTrue: [
+      clients isEmpty ifTrue: [
         clients removeAll.
         poker == nil ifFalse: [
           poker <-: finished ]
@@ -272,17 +309,15 @@ class Chat usingPlatform: platform = Value (
     )
 
     public poke: factory accu: accumulator = (
-      clients do: [:tuple |
-        tuple ~= nil ifTrue: [
-          tuple at: 2 put: ((tuple at: 2) <-: act: factory accu: accumulator) ] ]
+      clients doWithTuple: [:tuple |
+        tuple at: 2 put: ((tuple at: 2) <-: act: factory accu: accumulator) ]
     )
 
     public disconnect: p = (
       poker:: p.
 
-      clients do: [:tuple |
-        tuple ~= nil ifTrue: [
-          (tuple at: 2) <-: logout ] ]
+      clients doWithPromise: [:client |
+        client <-: logout ]
     )
   )
 

--- a/newspeak/chat.ns
+++ b/newspeak/chat.ns
@@ -15,6 +15,46 @@ class Chat usingPlatform: platform = Value (
   private BenchNoBufferedChats = false.
 |
 )(
+  private class IdPromiseVector new: size = Vector new: size (
+  | private nonEmptyElements ::= 0. |
+  )(
+    public append: id and: promise = (
+      self append: {id. promise}
+    )
+
+    public removeById: id <Integer> = (
+      doIndexes: [:i |
+        | tuple = promiseVec at: i. |
+        tuple ~= nil ifTrue: [
+          (tuple at: 1) = id ifTrue: [
+            promiseVec at: i put: nil.
+            nonEmptyElements:: nonEmptyElements - 1.
+            ^ true ] ] ].
+
+      ^ false
+
+      (* TODO: need to support indexed access *)
+    )
+
+    public doWithPromise: block = (
+      do: [:tuple |
+        tuple ~= nil ifTrue: [
+          block value: (tuple at: 2) ] ]
+    )
+
+    public size = (
+      ^ nonEmptyElements
+    )
+
+    public isEmpty = (
+      ^ nonEmptyElements = 0
+    )
+  ) : (
+    public new = (
+      ^ self new: 10
+    )
+  )
+
   class BehaviorFactory new: compute post: post leave: leave invite: invite = Value (
   | private compute = compute.
     private post    = self compute + post.
@@ -35,11 +75,13 @@ class Chat usingPlatform: platform = Value (
     )
   )
 
-  class Chat new: initiator = (
-  | members <Vector[FarReference[Client]]> = Vector new.
-    buffer  <Vector[Nil]>                  = Vector new.
+  class Chat new: initiator clientId: initiatorId chatId: chatId = (
+  | private initiatorId = initiatorId.
+    private chatId = chatId.
+    private members <IdPromiseVector[Integer,Promise[Client]]> = IdPromiseVector new.
+    private buffer  <Vector[Nil]>                              = Vector new.
   |
-    members append: initiator.
+    members append: initiatorId and: initiator.
   )(
     public post: payload <Array | nil> accu: accumulator = (
       BenchNoBufferedChats
@@ -49,12 +91,12 @@ class Chat usingPlatform: platform = Value (
         ifTrue: [ accumulator <-: stop: #post ]
         ifFalse: [
           accumulator <-: bump: members size act: #post.
-          members do: [:m |
+          members doWithPromise: [:m |
             m <-: forward: self payload: payload accu: accumulator ] ]
     )
 
-    public join: client <Promise[Client]> accu: accumulator = (
-      members append: client.
+    public join: client <Promise[Client]> id: clientId accu: accumulator = (
+      members append: clientId and: client.
 
       BenchNoBufferedChats ifFalse: [
         buffer size > 0 ifTrue: [
@@ -62,24 +104,26 @@ class Chat usingPlatform: platform = Value (
           buffer do: [:m |
             client <-: forward: self payload: m accu: accumulator ] ] ].
 
-      client <-: accept: self accu: accumulator.
+      client <-: accept: self chatId: chatId accu: accumulator.
     )
 
-    public leave: client didLogout: didLogout accu: accumulator = (
-      members remove: client.
-      client <-: left: self didLogout: didLogout accu: accumulator
+    public leave: client <Promise[Client]> clientId: clientId <Integer> didLogout: didLogout accu: accumulator = (
+      | removed |
+      removed:: members removeById: clientId.
+      client <-: left: chatId didLogout: didLogout accu: accumulator
     )
   )
 
   class Client create: id dir: directory seed: seed = (
   | private id = id.
-    private friends <Vector[FarReference[Client]]> = Vector new.
-    private chats   <Vector[FarReference[Chat]]>   = Vector new.
+    private friends <IdPromiseVector[Integer,Promise[Client]]> = IdPromiseVector new.
+    private chats   <IdPromiseVector[Integer,Promise[Chat]]>   = IdPromiseVector new.
     private directory = directory.
     private rand = SimpleRand new: seed.
+    private nextChatId ::= 0.
   |)(
-    public befriend: client <FarReference[Client]> = (
-      friends append: client
+    public befriend: client <Promise[Client]> clientId: friendId = (
+      friends append: friendId and: client
     )
 
     public logout = (
@@ -89,12 +133,12 @@ class Chat usingPlatform: platform = Value (
           directory <-: left: id.
           ^ self ].
 
-      chats do: [:c |
-        c <-: leave: self didLogout: true accu: nil ]
+      chats doWithPromise: [:c |
+        c <-: leave: self clientId: id didLogout: true accu: nil ]
     )
 
-    public left: chat <FarReference[Chat]> didLogout: didLogout accu: accumulator = (
-      chats remove: chat.
+    public left: chatId didLogout: didLogout accu: accumulator = (
+      chats removeById: chatId.
 
       (chats isEmpty and: [ didLogout ])
         ifTrue: [ directory <-: left: id ]
@@ -103,8 +147,8 @@ class Chat usingPlatform: platform = Value (
             accumulator <-: stop: #leave ] ]
     )
 
-    public accept: chat <FarReference[Chat]> accu: accumulator = (
-      chats append: chat.
+    public accept: chat <Promise[Chat]> chatId: chatId accu: accumulator = (
+      chats append: chatId and: chat.
       accumulator <-: stop: #ignore
     )
 
@@ -135,7 +179,7 @@ class Chat usingPlatform: platform = Value (
         chatsSize = 0 ifTrue: [
           accumulator <-: stop: #none.
           ^ self ].
-        (chats at: index) <-: post: nil accu: accumulator.
+        (chats promiseAt: index) <-: post: nil accu: accumulator.
         ^ self ].
 
       b = #leave ifTrue: [
@@ -144,7 +188,7 @@ class Chat usingPlatform: platform = Value (
           accumulator <-: stop: #none.
           ^ self ].
 
-        (chats at: index) <-: leave: self didLogout: false accu: accumulator.
+        (chats promiseAt: index) <-: leave: self clientId: id didLogout: false accu: accumulator.
         ^ self ].
 
       b = #compute ifTrue: [
@@ -154,8 +198,9 @@ class Chat usingPlatform: platform = Value (
         ^ self ].
 
       b = #invite ifTrue: [
-        | createdP <Promise[Chat]> = (actors createActorFromValue: Chat) <-: new: self.
-          f i invitations |
+        | createdP <Promise[Chat]> f i invitations |
+        nextChatId:: nextChatId + 1.
+        createdP:: (actors createActorFromValue: Chat) <-: new: self clientId: id chatId: (id << 20) + nextChatId.
         f:: friends asArray.
 
         rand shuffle: f.
@@ -174,7 +219,7 @@ class Chat usingPlatform: platform = Value (
 
         1 to: invitations do: [:i |
           | k = f at: i. |
-          createdP <-: join: k accu: accumulator ].
+          createdP <-: join: (k at: 2) id: (k at: 1) accu: accumulator ].
         ^ self ].
 
       (* else *)
@@ -183,8 +228,7 @@ class Chat usingPlatform: platform = Value (
   )
 
   class Directory new: seed with: befriend = (
-  | private clients <Vector[Array[Integer,Promise[Client]]]> = Vector new.
-    private numClients ::= 0.
+  | private clients <IdPromiseVector[Integer,Promise[Client]]> = IdPromiseVector new.
     private random = SimpleRand new: seed.
     private numBefriends = befriend.
     private completions ::= 0.
@@ -212,18 +256,6 @@ class Chat usingPlatform: platform = Value (
                 ifTrue: [
                   client <-: befriend: friend.
                   friend <-: befriend: client ] ] ] ] ]
-    )
-
-    private remove: clientId <Integer> = (
-      clients doIndexes: [:i |
-        | tuple = clients at: i. |
-        tuple ~= nil ifTrue: [
-          (tuple at: 1) = clientId ifTrue: [
-            numClients:: numClients - 1.
-            clients at: i put: nil.
-            ^ self ] ] ].
-
-      self error: 'Dir.left remove failed. clientId: ' + clientId
     )
 
     public left: clientId <Integer> = (

--- a/newspeak/chat.ns
+++ b/newspeak/chat.ns
@@ -54,7 +54,7 @@ class Chat usingPlatform: platform = Value (
             m <-: forward: self payload: payload accu: accumulator ] ]
     )
 
-    public join: client accu: accumulator = (
+    public join: client <Promise[Client]> accu: accumulator = (
       members append: client.
 
       BenchNoBufferedChats ifFalse: [
@@ -88,7 +88,7 @@ class Chat usingPlatform: platform = Value (
       chats isEmpty
         ifTrue: [
           (* TODO: should I avoid using IDs, is this allowed? *)
-          directory <-: left: self.
+          directory <-: left: id.
           ^ self ].
 
       chats do: [:c |
@@ -99,7 +99,7 @@ class Chat usingPlatform: platform = Value (
       chats remove: chat.
 
       (chats isEmpty and: [ didLogout ])
-        ifTrue: [ directory <-: left: self ]
+        ifTrue: [ directory <-: left: id ]
         ifFalse: [
           accumulator == nil ifFalse: [
             accumulator <-: stop: #leave ] ]
@@ -185,7 +185,8 @@ class Chat usingPlatform: platform = Value (
   )
 
   class Directory new: seed with: befriend = (
-  | private clients <Vector[FarReference[Client]]> = Vector new.
+  | private clients <Vector[Array[Integer,Promise[Client]]]> = Vector new.
+    private numClients ::= 0.
     private random = SimpleRand new: seed.
     private numBefriends = befriend.
     private completions ::= 0.
@@ -193,23 +194,44 @@ class Chat usingPlatform: platform = Value (
   |)(
     public login: id = (
       | newClient = (actors createActorFromValue: Client) <-: create: id dir: self seed: random next. |
-      ^ newClient whenResolved: [:nc |
-        clients append: nc ]
+      clients append: {id. newClient}.
+      numClients:: numClients + 1.
     )
 
     public befriend = (
-      clients do: [:friend |
-        clients do: [:client |
-          ((random nextInt: 100) < numBefriends and: [friend ~= client])
-            ifTrue: [
-              client <-: befriend: friend.
-              friend <-: befriend: client ] ] ]
+      clients do: [:friendTuple |
+        | friend fId |
+        friendTuple ~= nil ifTrue: [
+          friend:: friendTuple at: 2.
+          fId:: friendTuple at: 1.
+          clients do: [:clientTuple |
+            | client cId |
+            clientTuple ~= nil ifTrue: [
+              client:: clientTuple at: 2.
+              cId:: clientTuple at: 1.
+              (* at this point in time, we are guaranteed that *)
+              ((random nextInt: 100) < numBefriends and: [fId <> cId])
+                ifTrue: [
+                  client <-: befriend: friend.
+                  friend <-: befriend: client ] ] ] ] ]
     )
 
-    public left: client <FarReference[Client]> = (
-      clients remove: client.
+    private remove: clientId <Integer> = (
+      clients doIndexes: [:i |
+        | tuple = clients at: i. |
+        tuple ~= nil ifTrue: [
+          (tuple at: 1) = clientId ifTrue: [
+            numClients:: numClients - 1.
+            clients at: i put: nil.
+            ^ self ] ] ].
 
-      clients isEmpty ifTrue: [
+      self error: 'Dir.left remove failed. clientId: ' + clientId
+    )
+
+    public left: clientId <Integer> = (
+      remove: clientId.
+
+      numClients = 0 ifTrue: [
         clients removeAll.
         poker == nil ifFalse: [
           poker <-: finished ]
@@ -217,15 +239,17 @@ class Chat usingPlatform: platform = Value (
     )
 
     public poke: factory accu: accumulator = (
-      clients do: [:client |
-        client <-: act: factory accu: accumulator ]
+      clients do: [:tuple |
+        tuple ~= nil ifTrue: [
+          tuple at: 2 put: ((tuple at: 2) <-: act: factory accu: accumulator) ] ]
     )
 
     public disconnect: p = (
       poker:: p.
 
-      clients do: [:client |
-        client <-: logout ]
+      clients do: [:tuple |
+        tuple ~= nil ifTrue: [
+          (tuple at: 2) <-: logout ] ]
     )
   )
 
@@ -283,7 +307,7 @@ class Chat usingPlatform: platform = Value (
     private turns ::= numTurns.
     private iteration ::= 1.
     private rand = SimpleRand new: 42.
-    private directories = Array new: dirs withAll: [
+    private directories <Promise[Directory]> = Array new: dirs withAll: [
       (actors createActorFromValue: Directory) <-: new: rand next with: befriend ].
     private runtimes ::= Vector new.
     private accumulations ::= 0.

--- a/newspeak/chat.ns
+++ b/newspeak/chat.ns
@@ -242,20 +242,23 @@ class Chat usingPlatform: platform = Value (
 
     public befriend = (
       clients do: [:friendTuple |
-        | friend fId |
         friendTuple ~= nil ifTrue: [
+          | friend fId madeFriends |
           friend:: friendTuple at: 2.
           fId:: friendTuple at: 1.
-          clients do: [:clientTuple |
-            | client cId |
-            clientTuple ~= nil ifTrue: [
-              client:: clientTuple at: 2.
-              cId:: clientTuple at: 1.
-              (* at this point in time, we are guaranteed that *)
-              ((random nextInt: 100) < numBefriends and: [fId <> cId])
-                ifTrue: [
-                  client <-: befriend: friend.
-                  friend <-: befriend: client ] ] ] ] ]
+          madeFriends:: false.
+
+          [madeFriends] whileFalse: [
+            clients do: [:clientTuple |
+              clientTuple ~= nil ifTrue: [
+                | client cId |
+                client:: clientTuple at: 2.
+                cId:: clientTuple at: 1.
+                ((random nextInt: 100) < numBefriends and: [fId <> cId])
+                  ifTrue: [
+                    madeFriends:: true.
+                    client <-: befriend: friend.
+                    friend <-: befriend: client ] ] ] ] ] ]
     )
 
     public left: clientId <Integer> = (

--- a/newspeak/chat.ns
+++ b/newspeak/chat.ns
@@ -10,7 +10,6 @@ class Chat usingPlatform: platform = Value (
   private Vector      = platform kernel Vector.
   (* private IdentitySet = platform collections IdentitySet. *)
 
-  private DiceRoll    = utils DiceRoll.
   private SimpleRand  = utils SimpleRand.
 
   private BenchNoBufferedChats = false.
@@ -22,8 +21,8 @@ class Chat usingPlatform: platform = Value (
     private leave   = self post + leave.
     private invite  = self leave + invite.
   |)(
-    public determineAction: dice = (
-      | pick = dice next. |
+    public determineAction: rand = (
+      | pick = rand nextDiceRoll. |
       pick < compute
         ifTrue: [ ^ #compute ].
       pick < post
@@ -78,7 +77,6 @@ class Chat usingPlatform: platform = Value (
     private chats   <Vector[FarReference[Chat]]>   = Vector new.
     private directory = directory.
     private rand = SimpleRand new: seed.
-    private dice = DiceRoll new: rand.
   |)(
     public befriend: client <FarReference[Client]> = (
       friends append: client
@@ -130,7 +128,7 @@ class Chat usingPlatform: platform = Value (
     public act: behavior accu: accumulator = (
       | b index |
       index:: (rand nextInt: chats size) + 1.
-      b:: behavior determineAction: dice.
+      b:: behavior determineAction: rand.
 
       b = #post ifTrue: [
         | chatsSize = chats size. |

--- a/newspeak/util.ns
+++ b/newspeak/util.ns
@@ -33,15 +33,9 @@ class Util usingPlatform: platform = Value ()(
         array at: ceil put: (array at: randI).
         array at: randI put: tmp ]
     )
-  )
 
-  public class DiceRoll new: rand = (
-  | private random = rand. |
-  )(
-    public seed = ( ^ random seed )
-
-    public next = (
-      ^ random nextInt: 100
+    public nextDiceRoll = (
+      ^ nextLong % 100
     )
   )
 )


### PR DESCRIPTION
This gets the benchmark working.

Main changes:
 - use integers as ids everywhere to avoid having to unwrap promises
 - remove DiceRoll class, fold into SimpleRand
 - make sure clients have at least one friend (needed for small problem sizes)

This relies on a custom Vector implementation for a pair of id and promise.
The remove operation is a naive implementation that compacts the vector. This is conceptually what Pony seems to do, too. Not beautiful, but works.